### PR TITLE
allow titles to start with attribute references

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,4 +90,4 @@ Most of the commands, keymaps and some text in this readme are based on (or insp
 ## License
 
 This project is licensed under [MIT License](http://opensource.org/licenses/MIT/).
-For the full text of the license, see the [LICENSE](LICENSE) file.
+For the full text of the license, see the [LICENSE](LICENSE) file. 

--- a/Syntaxes/Asciidoctor.YAML-tmLanguage
+++ b/Syntaxes/Asciidoctor.YAML-tmLanguage
@@ -1050,42 +1050,42 @@ repository:
 
   title_level_0:
     name: markup.heading.level.0.asciidoc
-    match: ^(=) (\w.*)$\n?
+    match: ^(=) ({?\w.*)$\n?
     captures:
       '1': {name: punctuation.definition.heading.asciidoc}
       '2': {name: entity.name.section.asciidoc}
 
   title_level_1:
     name: markup.heading.level.1.asciidoc
-    match: ^(==) (\w.*)$\n?
+    match: ^(==) ({?\w.*)$\n?
     captures:
       '1': {name: punctuation.definition.heading.asciidoc}
       '2': {name: entity.name.section.asciidoc}
 
   title_level_2:
     name: markup.heading.level.2.asciidoc
-    match: ^(===) (\w.*)$\n?
+    match: ^(===) ({?\w.*)$\n?
     captures:
       '1': {name: punctuation.definition.heading.asciidoc}
       '2': {name: entity.name.section.asciidoc}
 
   title_level_3:
     name: markup.heading.level.3.asciidoc
-    match: ^(====) (\w.*)$\n?
+    match: ^(====) ({?\w.*)$\n?
     captures:
       '1': {name: punctuation.definition.heading.asciidoc}
       '2': {name: entity.name.section.asciidoc}
 
   title_level_4:
     name: markup.heading.level.4.asciidoc
-    match: ^(=====) (\w.*)$\n?
+    match: ^(=====) ({?\w.*)$\n?
     captures:
       '1': {name: punctuation.definition.heading.asciidoc}
       '2': {name: entity.name.section.asciidoc}
 
   title_level_5:
     name: markup.heading.level.5.asciidoc
-    match: ^(======) (\w.*)$\n?
+    match: ^(======) ({?\w.*)$\n?
     captures:
       '1': {name: punctuation.definition.heading.asciidoc}
       '2': {name: entity.name.section.asciidoc}

--- a/Syntaxes/Asciidoctor.tmLanguage
+++ b/Syntaxes/Asciidoctor.tmLanguage
@@ -2304,7 +2304,7 @@ Examples:
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^(=) (\w.*)$\n?</string>
+			<string>^(=) ({?\w.*)$\n?</string>
 			<key>name</key>
 			<string>markup.heading.level.0.asciidoc</string>
 		</dict>
@@ -2324,7 +2324,7 @@ Examples:
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^(==) (\w.*)$\n?</string>
+			<string>^(==) ({?\w.*)$\n?</string>
 			<key>name</key>
 			<string>markup.heading.level.1.asciidoc</string>
 		</dict>
@@ -2344,7 +2344,7 @@ Examples:
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^(===) (\w.*)$\n?</string>
+			<string>^(===) ({?\w.*)$\n?</string>
 			<key>name</key>
 			<string>markup.heading.level.2.asciidoc</string>
 		</dict>
@@ -2364,7 +2364,7 @@ Examples:
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^(====) (\w.*)$\n?</string>
+			<string>^(====) ({?\w.*)$\n?</string>
 			<key>name</key>
 			<string>markup.heading.level.3.asciidoc</string>
 		</dict>
@@ -2384,7 +2384,7 @@ Examples:
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^(=====) (\w.*)$\n?</string>
+			<string>^(=====) ({?\w.*)$\n?</string>
 			<key>name</key>
 			<string>markup.heading.level.4.asciidoc</string>
 		</dict>
@@ -2404,7 +2404,7 @@ Examples:
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^(======) (\w.*)$\n?</string>
+			<string>^(======) ({?\w.*)$\n?</string>
 			<key>name</key>
 			<string>markup.heading.level.5.asciidoc</string>
 		</dict>

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -7,6 +7,6 @@ set -e
 cd "$(dirname "$0")/.."
 
 echo '==> Installing development dependencies...'
-pip install -r requirements-dev.txt | sed -n '/Requirement already satisfied/!p'
+pip3 install -r requirements-dev.txt | sed -n '/Requirement already satisfied/!p'
 
 exit ${PIPESTATUS[0]}  # exit status of pip install


### PR DESCRIPTION
Changed the regular expressions for titles at all levels to allow a title to start with an attribute reference, e.g. `== {attr} Rest of Title`.